### PR TITLE
added support for swift-3.1-branch snapshots

### DIFF
--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -58,6 +58,10 @@ if translated_uri.nil?
   # Determine snapshot type, swift version, url...
   if requested_swift_version.downcase.include? "development"
     snapshot_type = "development"
+      # Check if swift-3.1-branch snapshot
+      if requested_swift_version.downcase.include? "3.1"
+        snapshot_type = "swift-3.1-branch"
+      end
   else
     snapshot_type = requested_swift_version.downcase
     if snapshot_type.include? "preview"


### PR DESCRIPTION
Hi, there is problem I stuck with .swift-version file, seems like there is no way to specify any of swift 3.1 snapshots because snapshot_type need to be swift-3.1-branch.
