### PR TITLE
Issue.three point one

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -219,7 +219,7 @@ else
   SWIFT_BUILD_OPTIONS=""
 fi
 
-if [ $BLUEMIX_APP_MGMT_ENABLE == *"debug"* ]; then
+if [[ $BLUEMIX_APP_MGMT_ENABLE == *"debug"* ]]; then
   BUILD_CONFIGURATION="debug"
 else
   BUILD_CONFIGURATION="release"

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -59,7 +59,7 @@ if translated_uri.nil?
   if requested_swift_version.downcase.include? "development"
     if /3.1/.match(requested_swift_version.downcase)
       STDERR.puts "-----> WARNING: CHRISTIAN"
-      snapshot_type =
+      snapshot_type = "swift-3.1-branch"
     else
       snapshot_type = "development"
     end

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -57,8 +57,8 @@ if translated_uri.nil?
 
   # Determine snapshot type, swift version, url...
   if requested_swift_version.downcase.include? "development"
+    # Check if requesting a branch development snapshot, 'swift-X.X-'
     if /swift-\d\.\d-/.match(requested_swift_version.downcase)
-      STDERR.puts "-----> WARNING: CHRISTIAN"
       snapshot_type = requested_swift_version.downcase[/swift-\d\.\d-/] + "branch"
     else
       snapshot_type = "development"

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -57,7 +57,7 @@ if translated_uri.nil?
 
   # Determine snapshot type, swift version, url...
   if requested_swift_version.downcase.include? "development"
-    if /3.1/.match(requested_swift_version.downcase)
+    if /swift-\d\.\d-/.match(requested_swift_version.downcase)
       STDERR.puts "-----> WARNING: CHRISTIAN"
       snapshot_type = "swift-3.1-branch"
     else

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -62,6 +62,7 @@ if translated_uri.nil?
       snapshot_type =
     else
       snapshot_type = "development"
+    end
   else
     snapshot_type = requested_swift_version.downcase
     if snapshot_type.include? "preview"

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -59,7 +59,7 @@ if translated_uri.nil?
   if requested_swift_version.downcase.include? "development"
     if /swift-\d\.\d-/.match(requested_swift_version.downcase)
       STDERR.puts "-----> WARNING: CHRISTIAN"
-      snapshot_type = "swift-3.1-branch"
+      snapshot_type = requested_swift_version.downcase[/swift-\d\.\d-/] + "branch"
     else
       snapshot_type = "development"
     end

--- a/compile-extensions/bin/download_dependency
+++ b/compile-extensions/bin/download_dependency
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 ##
-# Copyright IBM Corporation 2016
+# Copyright IBM Corporation 2016, 2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,11 @@ if translated_uri.nil?
 
   # Determine snapshot type, swift version, url...
   if requested_swift_version.downcase.include? "development"
-    snapshot_type = "development"
+    if /3.1/.match(requested_swift_version.downcase)
+      STDERR.puts "-----> WARNING: CHRISTIAN"
+      snapshot_type =
+    else
+      snapshot_type = "development"
   else
     snapshot_type = requested_swift_version.downcase
     if snapshot_type.include? "preview"


### PR DESCRIPTION
- Adding ability to download 3.1 and other X.X pre-release development branch snapshots
- Fix `/tmp/buildpacks/6de240d95e909d7912afaca8a6b0bac8/bin/compile: line 222: [: ==: unary operator expected` Error