### PR TITLE
fix processing deb files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -279,7 +279,7 @@ rm -rf $CACHE_DIR/"$SWIFT_NAME_VERSION.tar.gz"
 rm -rf $CACHE_DIR/"$CLANG_NAME_VERSION.tar.xz"
 deb_files=($BP_DIR/binary-dependencies/*.deb)
 if [ -f "${deb_files[0]}" ]; then
-  for DEB in deb_files; do
+  for DEB in ${deb_files[@]}; do
     rm $APT_CACHE_DIR/archives/$(basename $DEB)
   done
 fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -144,7 +144,7 @@ download_packages() {
 install_packages() {
   deb_files=($APT_CACHE_DIR/archives/*.deb)
   if [ -f "${deb_files[0]}" ]; then
-    for DEB in deb_files; do
+    for DEB in ${deb_files[@]}; do
       status "Installing $(basename $DEB)"
       dpkg -x $DEB $BUILD_DIR/.apt/
     done


### PR DESCRIPTION
Fixes a regression in the 2.0.5 release which caused staging to fail whenever an Aptfile was used to specify system dependencies to be installed.