### PR TITLE
cf-cli 6.26.0 support for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb http://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
   - sudo apt-get update
-  - sudo apt-get install cf-cli
+  - sudo apt-get install cf-cli=6.26.0
   - export CF_DIAL_TIMEOUT=30
   - cf version
   - cf login -a https://$BLUEMIX_REGION -u $BLUEMIX_USER -p $BLUEMIX_PASS -s applications-ci -o $BLUEMIX_USER

--- a/ci/performance_validator.sh
+++ b/ci/performance_validator.sh
@@ -70,8 +70,11 @@ passed_repush=$?
 cd ..
 
 # Verify 200 from application route status code
-url=$(cf app Kitura-Starter | grep urls:)
-status=$(curl -s -o /dev/null -w '%{http_code}' ${url#urls: })
+cf app Kitura-Starter
+url=$(cf app Kitura-Starter | grep routes:)
+echo "Obtained application route assignment: $url"
+status=$(curl -s -o /dev/null -w '%{http_code}' ${url#routes: })
+echo "cURL application route status:  $status"
 [ "$status" = 200 ] ; url_success=$?
 
 ! (( $passed | $passed_repush | $url_success ));

--- a/ci/performance_validator.sh
+++ b/ci/performance_validator.sh
@@ -70,11 +70,11 @@ passed_repush=$?
 cd ..
 
 # Verify 200 from application route status code
-cf app Kitura-Starter
-url=$(cf app Kitura-Starter | grep routes:)
-echo "Obtained application route assignment: $url"
+cf app $APPLICATION_DIR
+url=$(cf app $APPLICATION_DIR | grep routes:)
+echo "Obtained $APPLICATION_DIR route assignment: $url"
 status=$(curl -s -o /dev/null -w '%{http_code}' ${url#routes: })
-echo "cURL application route status:  $status"
+echo "cURL $APPLICATION_DIR route status:  $status"
 [ "$status" = 200 ] ; url_success=$?
 
 ! (( $passed | $passed_repush | $url_success ));


### PR DESCRIPTION
The recent upgrade to cf cli version 6.26.0 uses the `routes:` attribute, as opposed to `urls:` which was used previously in the return of the `cf app <NAME>` command. This broke our continuous integration testing, where we extract the application route to cURL for 200 status as part of our performance validation testing.

This code change requests a specific version of the Cloud Foundry CLI, `cf-cli=6.26.0`, and now uses the `routes:` attribute.

v6.26.0:
![screen shot 2017-04-11 at 9 59 14 am](https://cloud.githubusercontent.com/assets/18534315/24919823/7f652a26-1eaa-11e7-9823-ba48f4694481.png)


v6.25.0:
![screen shot 2017-04-11 at 11 42 29 am](https://cloud.githubusercontent.com/assets/18534315/24920208/06de4dc4-1eac-11e7-8954-2e2cff6b17cb.png)


