### PR TITLE
Remove extra files from packaged buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -61,3 +61,6 @@ exclude_files:
   - cf_build/
   - .travis.yml
   - ci/
+  - coverage/
+  - servicemanifest.json
+  - credentials-buildpack-test


### PR DESCRIPTION
There is no need to include the coverage folder or service manifest in the final buildpack, now they will be excluded in the manifest.yml file.