### PR TITLE
Add support for user specified env vars

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -130,6 +130,18 @@ else
 fi
 
 # ----------------------------------------------------------------------------- #
+	# Set any user specified build environment variables.                            #
+	# (Note, this is currently required in order to use Kitura with SwiftNIO.)
+	# ----------------------------------------------------------------------------- #
+	if [ -f $BUILD_DIR/.build_env ]; then
+	  status ".build_env found."
+	  for ENV_VAR in $(cat $BUILD_DIR/.build_env); do
+	    export $ENV_VAR
+	    status "Set build environment variable: $ENV_VAR"
+	  done
+	fi
+
+# ----------------------------------------------------------------------------- #
 # Install Swift dev tools & clang                                               #
 # ----------------------------------------------------------------------------- #
 # Determine Swift version for the app


### PR DESCRIPTION
@helenmasters Since your forked repository PR won't work with the Travis build, I've moved your changes to this PR so we can properly test it.

Adding support for issue #113.
WIP as if this approach is agreed on we will also need to add this to the README.

The current suggested approach is to have a file called: .build_env which would contain a list of env variables to be set, where each environment variable to be set would be on a separate line e.g:
KITURA_NIO=1
FOO=bar
these would then be exported by the script to be available when the swift build and swift package resolve commands get executed.